### PR TITLE
Edit event views

### DIFF
--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -901,7 +901,7 @@ class Schedule(commands.Cog):
             event[modal.custom_id[len("modal_"):]] = None
 
         elif modal.custom_id == "modal_reservableRoles":
-            # TODO fix reserve button
+            # TODO show/hide reserve button on roles/None
             reservableRoles = value.split("\n")
             if len(reservableRoles) > 25:
                 await interaction.response.send_message(embed=Embed(title="❌ Ain't supporting over 25 roles bruh", color=Color.red()), ephemeral=True, delete_after=10.0)
@@ -916,6 +916,7 @@ class Schedule(commands.Cog):
                 event["reservableRoles"] = {role: event["reservableRoles"][role] if role in event["reservableRoles"] else None for role in reservableRoles}
 
         elif modal.custom_id == "modal_maxPlayers":
+            # TODO show/hide buttons on "hidden"
             if value.lower() == "none" or (value.isdigit() and int(value) > MAX_SERVER_ATTENDANCE):
                 event["maxPlayers"] = None
             elif value.lower() in ("anonymous", "hidden"):

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -941,17 +941,6 @@ class Schedule(commands.Cog):
         elif modal.custom_id == "modal_time":
             # TODO add event collision and shit from eventTime()
             # TODO reorder events
-            """
-            Instead of update channel:
-            oldEventsOrder = events
-            newEventsOrder = sorted(events)
-            if oldEventsOrder[pos] == newEventsOrder[pos]:
-                oldEventsOrder.pop(pos)
-            # now you're left with affected events.
-            for newEvent in newEventsOrder:
-                oldEventOrder.message.edit(embed=newEvent, view=view)
-            # This way you only edit the events that are affected and not resending the entire shit
-            """
 
             startTimeOld = event["time"]
             hours, minutes, delta = self.getDetailsFromDuration(event["duration"])
@@ -979,6 +968,33 @@ class Schedule(commands.Cog):
                         await member.send(embed=embed)
                     except Exception as e:
                         log.exception(f"{member} | {e}")
+
+            with open(EVENTS_FILE, "w") as f:
+                json.dump(events, f, indent=4)
+
+            # await eventMsg.edit(embed=self.getEventEmbed(event))
+            await interaction.response.send_message(embed=Embed(title="✅ Event edited", color=Color.green()), ephemeral=True, delete_after=5.0)
+
+            # Reorder events
+            """
+            Instead of update channel:
+            oldEventsOrder = events
+            newEventsOrder = sorted(events)
+            if oldEventsOrder[pos] == newEventsOrder[pos]:
+                oldEventsOrder.pop(pos)
+            # now you're left with affected events.
+            for newEvent in newEventsOrder:
+                oldEventOrder.message.edit(embed=newEvent, view=view)
+            # This way you only edit the events that are affected and not resending the entire shit
+            """
+            sortedEvents = sorted(events, key=lambda e: datetime.strptime(e["time"], TIME_FORMAT), reverse=True)
+            for idx, eve in enumerate(events):
+                if eve["messageId"] != sortedEvents[idx]:
+                    msgId = eve["messageId"]
+                    events[idx] = sortedEvents[idx]
+                    events[idx]["messageId"] = msgId
+            return
+
 
         else:
             event[modal.custom_id[len("modal_"):]] = value

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -1,7 +1,6 @@
 import os, re, json, asyncio, random, discord
 import pytz  # type: ignore
 
-from pprint import pprint
 from math import ceil
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -587,13 +586,6 @@ class Schedule(commands.Cog):
 
                 event = [event for event in events if event["messageId"] == message.id][0]
                 await self.editEvent(interaction, event, message)
-                #if reorderEvents:
-                #    with open(EVENTS_FILE, "w") as f:
-                #        json.dump(events, f, indent=4)
-                #    await self.updateSchedule()
-                #    return
-                #else:
-                #    await message.edit(embed=self.getEventEmbed(event))
 
             elif button.custom_id == "delete":
                 if message is None:
@@ -799,20 +791,20 @@ class Schedule(commands.Cog):
                 await interaction.response.send_message(view=view, ephemeral=True, delete_after=60.0)
 
             # TODO Editing Template Name
-            elif editOption == "Template Name":
-                embed = Embed(title=SCHEDULE_EVENT_TEMPLATE_SAVE_NAME_QUESTION, color=Color.gold())
-                embed.set_footer(text=SCHEDULE_CANCEL)
-                await interaction.user.send(embed=embed)
-                try:
-                    response = await self.bot.wait_for("message", timeout=TIME_TEN_MIN, check=lambda msg, author=interaction.user, dmChannel=dmChannel: msg.channel == dmChannel and msg.author == author)
-                    templateName = response.content.strip()
-                    if templateName.lower() == "cancel":
-                        await self.cancelCommand(dmChannel, "Event editing")
-                        return None
-                except asyncio.TimeoutError:
-                    await interaction.user.send(embed=TIMEOUT_EMBED)
-                    return None
-                event["name"] = templateName
+            #elif editOption == "Template Name":
+            #    embed = Embed(title=SCHEDULE_EVENT_TEMPLATE_SAVE_NAME_QUESTION, color=Color.gold())
+            #    embed.set_footer(text=SCHEDULE_CANCEL)
+            #    await interaction.user.send(embed=embed)
+            #    try:
+            #        response = await self.bot.wait_for("message", timeout=TIME_TEN_MIN, check=lambda msg, author=interaction.user, dmChannel=dmChannel: msg.channel == dmChannel and msg.author == author)
+            #        templateName = response.content.strip()
+            #        if templateName.lower() == "cancel":
+            #            await self.cancelCommand(dmChannel, "Event editing")
+            #            return None
+            #    except asyncio.TimeoutError:
+            #        await interaction.user.send(embed=TIMEOUT_EMBED)
+            #        return None
+            #    event["name"] = templateName
 
             # Editing Title
             elif editOption == "Title":

--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -940,6 +940,17 @@ class Schedule(commands.Cog):
         elif modal.custom_id == "modal_time":
             # TODO add event collision and shit from eventTime()
             # TODO reorder events
+            """
+            Instead of update channel:
+            oldEventsOrder = events
+            newEventsOrder = sorted(events)
+            if oldEventsOrder[pos] == newEventsOrder[pos]:
+                oldEventsOrder.pop(pos)
+            # now you're left with affected events.
+            for newEvent in newEventsOrder:
+                oldEventOrder.message.edit(embed=newEvent, view=view)
+            # This way you only edit the events that are affected and not resending the entire shit
+            """
 
             startTimeOld = event["time"]
             hours, minutes, delta = self.getDetailsFromDuration(event["duration"])

--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ if not os.path.exists("./tmp"):  # Mission missionUploader stuff- TODO maybe cre
     os.mkdir("tmp")
 
 COGS = [cog[:-3] for cog in os.listdir("cogs/") if cog.endswith(".py")]
+# COGS = ["schedule"]  # Faster startup
 cogsReady = {cog: False for cog in COGS}
 
 INTENTS = discord.Intents.all()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
-import os, re, pytz, asyncio, discord
+import os, re, asyncio, discord
+import pytz # type: ignore
 
 from logger import Logger
 log = Logger()

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ if not os.path.exists("./tmp"):  # Mission missionUploader stuff- TODO maybe cre
     os.mkdir("tmp")
 
 COGS = [cog[:-3] for cog in os.listdir("cogs/") if cog.endswith(".py")]
-# COGS = ["schedule"]  # Faster startup
+COGS = ["schedule"]  # Faster startup
 cogsReady = {cog: False for cog in COGS}
 
 INTENTS = discord.Intents.all()

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ if not os.path.exists("./tmp"):  # Mission missionUploader stuff- TODO maybe cre
     os.mkdir("tmp")
 
 COGS = [cog[:-3] for cog in os.listdir("cogs/") if cog.endswith(".py")]
-COGS = ["schedule"]  # Faster startup
+#COGS = ["schedule"]  # Faster startup
 cogsReady = {cog: False for cog in COGS}
 
 INTENTS = discord.Intents.all()


### PR DESCRIPTION
Editing events now go directly in schedule channel with the use of dropdowns and modals, instead of going through DMs.
Editing the event time/attendance/reservable roles will solely edit the message(s) instead of resending the entire channel.
Temporarily disabled template editing and deletion due to conflicting code. Will fix soon™