### PR TITLE
refactor(schedule.py): No longer sending 2 schedule accepted reminders

### DIFF
--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -311,24 +311,22 @@ class Schedule(commands.Cog):
                 if utcNow > startTime + timedelta(minutes=30):
                     acceptedMembers = [member for memberId in event["accepted"] + event["standby"] if (member := guild.get_member(memberId)) is not None]
                     onlineMembers = self.bot.get_channel(COMMAND).members + self.bot.get_channel(DEPLOYED).members
+                    unScheduledMembers = []
                     acceptedMembersNotOnline = []
                     onlineMembersNotAccepted = []
                     for member in acceptedMembers:
                         if member not in onlineMembers and member not in acceptedMembersNotOnline:
-                            acceptedMembersNotOnline.append(member)
+                            unScheduledMembers.append(member)
                     for member in onlineMembers:
                         if member.id != event["authorId"] and member not in acceptedMembers and member not in onlineMembersNotAccepted:
-                            onlineMembersNotAccepted.append(member)
+                            unScheduledMembers.append(member)
 
                     event["checkedAcceptedReminders"] = True
                     with open(EVENTS_FILE, "w") as f:
                         json.dump(events, f, indent=4)
-                    if len(acceptedMembersNotOnline) > 0:
-                        log.debug(f"Schedule tenMinTask: Pinging members in accepted not in VC: {', '.join([member.display_name for member in acceptedMembersNotOnline])}")
-                        await channelArmaDiscussion.send(" ".join(member.mention for member in acceptedMembersNotOnline) + f" If you are in-game, please get in <#{COMMAND}> or <#{DEPLOYED}>. If you are not making it to this {event['type'].lower()}, please hit decline ❌ on the <#{SCHEDULE}>.")
-                    if len(onlineMembersNotAccepted) > 0:
-                        log.debug(f"Schedule tenMinTask: Pinging members in VC not in accepted: {', '.join([member.display_name for member in onlineMembersNotAccepted])}")
-                        await channelArmaDiscussion.send(" ".join(member.mention for member in onlineMembersNotAccepted) + f" If you are in-game, please hit accept ✅ on the <#{SCHEDULE}>.")
+                    if len(unScheduledMembers) > 0:
+                        log.debug(f"Schedule tenMinTask: Pinging un-shceduled members: {', '.join([member.display_name for member in unScheduledMembers])}")
+                        await channelArmaDiscussion.send(" ".join(member.mention for member in unScheduledMembers) + f"\nIf you are in-game, please:\n* Get in <#{COMMAND}> or <#{DEPLOYED}>.\n* Hit accept ✅ on the <#{SCHEDULE}>.\nIf you are not making it to this {event['type'].lower()}, please hit decline ❌ on the <#{SCHEDULE}>.")
         except Exception as e:
             log.exception(e)
 


### PR DESCRIPTION
When pinging schedule reminders:
* [Before](https://github.com/user-attachments/assets/3df47a75-7e73-4237-8acb-da6bbf37ee35) when the reminders were being sent as 2 different messages
* [After](https://github.com/user-attachments/assets/272240ff-4d7b-4b6f-962b-cedf5744ecd5) the format is re-structured and sent as one message