### PR TITLE
refactor(scheduly.py): Removed recruitment team ping when candidate accepts

### DIFF
--- a/cogs/schedule.py
+++ b/cogs/schedule.py
@@ -1028,7 +1028,7 @@ class Schedule(commands.Cog):
 
                     embed = discord.Embed(title="Candidate Accept", description=f"{interaction.user.mention} accepted operation `{eventList[0]['title']}`", color=discord.Color.blue())
                     embed.set_footer(text=f"Candidate ID: {interaction.user.id}")
-                    await channelRecruitmentHr.send(roleRecruitmentTeam.mention, embed=embed)
+                    await channelRecruitmentHr.send(embed=embed)
 
             elif customId == "reserve":
                 # Check if blacklisted


### PR DESCRIPTION
Requested:
Removed ping when a candidate accepts an op. Message is still posted with no @recruitment team ping.

![image](https://github.com/user-attachments/assets/0afab451-7d4a-4b64-9dbf-7188a22ea4f6)
